### PR TITLE
fix: replace deprecated datetime.utcnow() with timezone-aware alternative

### DIFF
--- a/skills/claw-mail/scripts/calendar_invite.py
+++ b/skills/claw-mail/scripts/calendar_invite.py
@@ -31,7 +31,7 @@ import json
 import os
 import sys
 import uuid
-from datetime import datetime
+from datetime import datetime, timezone
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 
@@ -57,7 +57,7 @@ def build_vcalendar(
 ) -> str:
     """Build an iCalendar VCALENDAR string for a VEVENT."""
     uid = uid or f"{uuid.uuid4()}@clawMail"
-    now = datetime.utcnow().strftime("%Y%m%dT%H%M%SZ")
+    now = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
     dtstart = start.strftime("%Y%m%dT%H%M%S")
     dtend = end.strftime("%Y%m%dT%H%M%S")
 

--- a/skills/claw-mail/scripts/lib/smtp_client.py
+++ b/skills/claw-mail/scripts/lib/smtp_client.py
@@ -8,7 +8,7 @@ import smtplib
 import socket
 import ssl
 import uuid
-from datetime import datetime
+from datetime import datetime, timezone
 from email import encoders
 from email.mime.base import MIMEBase
 from email.mime.multipart import MIMEMultipart
@@ -149,7 +149,7 @@ class SMTPClient:
                     if message.sender and "@" in str(message.sender)
                     else "localhost"
                 )
-            msg_id = f"{int(datetime.utcnow().timestamp() * 1000)}.{uuid.uuid4().hex}@{hostname}"
+            msg_id = f"{int(datetime.now(timezone.utc).timestamp() * 1000)}.{uuid.uuid4().hex}@{hostname}"
             message.message_id = f"<{msg_id}>"
             mime_msg["Message-ID"] = message.message_id
 


### PR DESCRIPTION
Fixes #2

Replaces `datetime.utcnow()` with `datetime.now(timezone.utc)` in:
- `scripts/calendar_invite.py` — calendar event timestamp generation
- `scripts/lib/smtp_client.py` — Message-ID generation

`datetime.utcnow()` was deprecated in Python 3.12 as it returns a naive datetime despite implying UTC.